### PR TITLE
Refined front‑end look

### DIFF
--- a/podcast_pipeline/static/style.css
+++ b/podcast_pipeline/static/style.css
@@ -1,30 +1,31 @@
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background-color: #f2f2f5;
+  line-height: 1.6;
+}
+
+.container {
+  max-width: 960px;
+}
+
 #drop_zone {
-  border: 2px dashed #888;
-  border-radius: 8px;
+  border: 2px dashed #bbb;
+  border-radius: 12px;
   width: 300px;
   height: 150px;
   line-height: 150px;
   text-align: center;
-  color: #888;
+  color: #666;
   margin: 50px auto;
-  font-size: 1.2rem;
+  font-size: 1.1rem;
+  background-color: #fafafa;
+  transition: background-color 0.2s, border-color 0.2s;
 }
+
 #drop_zone.hover {
-  border-color: #444;
-  color: #444;
-}
-body {
-  font-family: sans-serif;
-  max-width: 800px;
-  margin: 2rem auto;
-  padding: 0 1rem;
-  line-height: 1.6;
-}
-pre {
-  background: #f4f4f4;
-  padding: 1rem;
-  border-radius: 4px;
-  overflow-x: auto;
+  border-color: #007aff;
+  color: #007aff;
+  background-color: #f5f5f5;
 }
 
 #drop_zone button {
@@ -32,6 +33,40 @@ pre {
   padding: 0.5rem 1rem;
   font-size: 1rem;
   cursor: pointer;
+  background-color: #007aff;
+  border-color: #007aff;
+}
+
+#drop_zone button:hover {
+  background-color: #0065d1;
+  border-color: #0065d1;
+}
+
+.btn-primary {
+  background-color: #007aff;
+  border-color: #007aff;
+}
+
+.btn-primary:hover {
+  background-color: #0065d1;
+  border-color: #0065d1;
+}
+
+pre {
+  background: #fafafa;
+  padding: 1rem;
+  border-radius: 8px;
+  overflow-x: auto;
+}
+
+.card {
+  border: none;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+
+.card-title {
+  font-weight: 500;
 }
 
 #records_list {

--- a/podcast_pipeline/templates/index.html
+++ b/podcast_pipeline/templates/index.html
@@ -6,13 +6,16 @@
   <title>Podcast Pipeline</title>
   <!-- Bootstrap CSS -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="/static/style.css" rel="stylesheet">
 </head>
 <body>
-  <div class="container py-4">
-    <div class="d-flex align-items-center mb-4">
-      <h1 class="me-auto">Podcast Pipeline</h1>
-      <a href="/scheduler" class="btn btn-outline-secondary">Scheduler</a>
+  <nav class="navbar navbar-light bg-white shadow-sm mb-4">
+    <div class="container">
+      <a class="navbar-brand fw-semibold" href="/">Podcast Pipeline</a>
+      <a href="/scheduler" class="btn btn-outline-primary">Scheduler</a>
     </div>
+  </nav>
+  <div class="container pb-4">
 
     <div id="drop_zone" class="border border-secondary rounded p-4 text-center mb-4" style="border-style: dashed;">
       <p class="mb-2">Drop video or audio file here</p>

--- a/podcast_pipeline/templates/record.html
+++ b/podcast_pipeline/templates/record.html
@@ -6,9 +6,16 @@
   <title>Episode Details: {{ record.filename }}</title>
   <!-- Bootstrap CSS -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="/static/style.css" rel="stylesheet">
 </head>
 <body>
-  <div class="container py-4">
+  <nav class="navbar navbar-light bg-white shadow-sm mb-4">
+    <div class="container">
+      <a class="navbar-brand fw-semibold" href="/">Podcast Pipeline</a>
+      <a href="/scheduler" class="btn btn-outline-primary">Scheduler</a>
+    </div>
+  </nav>
+  <div class="container pb-4">
     <h1 class="mb-3">Episode Details: {{ record.filename }}</h1>
     <p><strong>Uploaded at:</strong> {{ record.upload_time }}</p>
     {% if record.original_duration is defined %}

--- a/podcast_pipeline/templates/result.html
+++ b/podcast_pipeline/templates/result.html
@@ -6,9 +6,16 @@
   <title>Podcast Pipeline Results</title>
   <!-- Bootstrap CSS -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="/static/style.css" rel="stylesheet">
 </head>
 <body>
-  <div class="container py-4">
+  <nav class="navbar navbar-light bg-white shadow-sm mb-4">
+    <div class="container">
+      <a class="navbar-brand fw-semibold" href="/">Podcast Pipeline</a>
+      <a href="/scheduler" class="btn btn-outline-primary">Scheduler</a>
+    </div>
+  </nav>
+  <div class="container pb-4">
     <h1 class="mb-4">Processing Results for {{ filename }}</h1>
 
     <div class="mb-4">

--- a/podcast_pipeline/templates/scheduler.html
+++ b/podcast_pipeline/templates/scheduler.html
@@ -6,9 +6,15 @@
   <title>Scheduler</title>
   <!-- Bootstrap CSS -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="/static/style.css" rel="stylesheet">
 </head>
 <body>
-  <div class="container py-4">
+  <nav class="navbar navbar-light bg-white shadow-sm mb-4">
+    <div class="container">
+      <a class="navbar-brand fw-semibold" href="/">Podcast Pipeline</a>
+    </div>
+  </nav>
+  <div class="container pb-4">
     <h1 class="mb-4">Episode Scheduler</h1>
 
     <h2>Publication Calendar</h2>


### PR DESCRIPTION
## Summary
- polish styling in `style.css` to mimic Apple-like aesthetics
- add navbar across templates and link stylesheet

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68483c6220908326a7ec34901e0bc855