### PR TITLE
Harden upload handling with validation and tests

### DIFF
--- a/clipmato/config.py
+++ b/clipmato/config.py
@@ -16,6 +16,18 @@ STATIC_DIR = BASE_DIR / "static"
 UPLOAD_DIR = BASE_DIR / "uploads"
 UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
 METADATA_PATH = UPLOAD_DIR / "metadata.json"
+ALLOWED_UPLOAD_MIME_TYPES: set[str] = {
+    "audio/flac",
+    "audio/m4a",
+    "audio/mp4",
+    "audio/mpeg",
+    "audio/ogg",
+    "audio/opus",
+    "audio/wav",
+    "audio/webm",
+    "audio/x-wav",
+}
+MAX_UPLOAD_SIZE_BYTES = 50 * 1024 * 1024  # 50MB limit for uploads
 
 # Mapping of pipeline stages to progress percentages
 STAGE_PROGRESS: dict[str, int] = {

--- a/clipmato/utils/file_io.py
+++ b/clipmato/utils/file_io.py
@@ -1,17 +1,80 @@
-import shutil
-from fastapi import UploadFile
-from ..config import UPLOAD_DIR
+import re
+from pathlib import Path
+from uuid import uuid4
+
+from fastapi import HTTPException, UploadFile
+
+from ..config import (
+    ALLOWED_UPLOAD_MIME_TYPES,
+    MAX_UPLOAD_SIZE_BYTES,
+    UPLOAD_DIR,
+)
 
 # Directory where uploaded files are stored
 upload_dir = UPLOAD_DIR
 upload_dir.mkdir(parents=True, exist_ok=True)
 
+_SAFE_FILENAME_PATTERN = re.compile(r"[^A-Za-z0-9_.-]")
+
+
+def sanitize_filename(filename: str) -> str:
+    """Remove path separators and unsafe characters from a filename."""
+    normalized = filename.replace("\\", "/")
+    name = Path(normalized).name
+    sanitized = _SAFE_FILENAME_PATTERN.sub("_", name)
+    return sanitized or "upload"
+
+
+def generate_unique_filename(filename: str) -> str:
+    """Return a sanitized filename suffixed with a UUID to prevent collisions."""
+    sanitized = sanitize_filename(filename)
+    base = Path(sanitized).stem or "upload"
+    suffix = Path(sanitized).suffix
+    return f"{base}_{uuid4().hex}{suffix}"
+
+
+def _validate_content_type(upload_file: UploadFile) -> None:
+    """Ensure the uploaded file's MIME type is permitted."""
+    if upload_file.content_type not in ALLOWED_UPLOAD_MIME_TYPES:
+        allowed = ", ".join(sorted(ALLOWED_UPLOAD_MIME_TYPES))
+        raise HTTPException(
+            status_code=415,
+            detail=f"Unsupported media type. Allowed types: {allowed}",
+        )
+
+
+def _copy_file_with_limit(upload_file: UploadFile, destination: Path) -> int:
+    """Copy an UploadFile to destination while enforcing the maximum size."""
+    total = 0
+    try:
+        with open(destination, "wb") as buffer:
+            while True:
+                chunk = upload_file.file.read(1024 * 1024)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > MAX_UPLOAD_SIZE_BYTES:
+                    raise HTTPException(
+                        status_code=413,
+                        detail="File too large. Maximum size is"
+                        f" {MAX_UPLOAD_SIZE_BYTES // (1024 * 1024)} MB.",
+                    )
+                buffer.write(chunk)
+    except Exception:
+        if destination.exists():
+            destination.unlink()
+        raise
+    return total
+
+
 def save_upload_file(upload_file: UploadFile) -> str:
     """
     Save an uploaded FastAPI UploadFile to the uploads directory
+    after validating its MIME type and size, using a unique filename,
     and return its file path.
     """
-    dest = upload_dir / upload_file.filename
-    with open(dest, "wb") as buffer:
-        shutil.copyfileobj(upload_file.file, buffer)
+    _validate_content_type(upload_file)
+    upload_file.file.seek(0)
+    dest = upload_dir / generate_unique_filename(upload_file.filename)
+    _copy_file_with_limit(upload_file, dest)
     return str(dest)

--- a/tests/test_file_io.py
+++ b/tests/test_file_io.py
@@ -1,0 +1,74 @@
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException, UploadFile
+
+from clipmato.utils import file_io
+
+
+@pytest.fixture(autouse=True)
+def isolate_upload_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(file_io, "upload_dir", tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+
+
+def test_sanitize_filename_removes_paths_and_invalid_chars():
+    sanitized = file_io.sanitize_filename("../unsafe/na/me?.wav")
+    assert ".." not in sanitized
+    assert "/" not in sanitized
+    assert "?" not in sanitized
+
+
+def test_save_upload_file_generates_unique_names(monkeypatch):
+    monkeypatch.setattr(
+        file_io, "ALLOWED_UPLOAD_MIME_TYPES", {"audio/wav"}, raising=False
+    )
+    content = b"12345"
+    upload1 = UploadFile(
+        filename="track.wav",
+        file=BytesIO(content),
+        headers={"content-type": "audio/wav"},
+    )
+    upload2 = UploadFile(
+        filename="track.wav",
+        file=BytesIO(content),
+        headers={"content-type": "audio/wav"},
+    )
+
+    first_path = Path(file_io.save_upload_file(upload1))
+    second_path = Path(file_io.save_upload_file(upload2))
+
+    assert first_path.name != second_path.name
+    assert first_path.exists()
+    assert second_path.exists()
+
+
+def test_save_upload_file_rejects_disallowed_mime(monkeypatch):
+    monkeypatch.setattr(
+        file_io, "ALLOWED_UPLOAD_MIME_TYPES", {"audio/wav"}, raising=False
+    )
+    upload = UploadFile(
+        filename="track.wav",
+        file=BytesIO(b"12345"),
+        headers={"content-type": "text/plain"},
+    )
+    with pytest.raises(HTTPException) as exc:
+        file_io.save_upload_file(upload)
+    assert exc.value.status_code == 415
+
+
+def test_save_upload_file_rejects_large_files(monkeypatch):
+    monkeypatch.setattr(file_io, "MAX_UPLOAD_SIZE_BYTES", 5, raising=False)
+    monkeypatch.setattr(
+        file_io, "ALLOWED_UPLOAD_MIME_TYPES", {"audio/wav"}, raising=False
+    )
+    upload = UploadFile(
+        filename="track.wav",
+        file=BytesIO(b"123456789"),
+        headers={"content-type": "audio/wav"},
+    )
+    with pytest.raises(HTTPException) as exc:
+        file_io.save_upload_file(upload)
+    assert exc.value.status_code == 413
+    assert not list(file_io.upload_dir.iterdir())

--- a/tests/test_upload_router.py
+++ b/tests/test_upload_router.py
@@ -1,0 +1,76 @@
+from io import BytesIO
+import os
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+from clipmato.routers.upload import router
+from clipmato.utils import file_io
+
+
+class DummyFileIO:
+    def __init__(self, save_callable):
+        self.save = save_callable
+
+
+def build_app(file_io_service):
+    app = FastAPI()
+    app.include_router(router)
+    # Override only the file IO service; other dependencies use lightweight fallbacks
+    from clipmato.dependencies import get_file_io_service, get_processing_service, get_progress_service
+
+    class DummyProcessing:
+        async def process(self, *args, **kwargs):
+            return None
+
+    class DummyProgress:
+        def update(self, *args, **kwargs):
+            return None
+
+        def read(self, record_id):
+            return {"stage": "pending", "progress": 0}
+
+    app.dependency_overrides[get_file_io_service] = lambda: file_io_service
+    app.dependency_overrides[get_processing_service] = lambda: DummyProcessing()
+    app.dependency_overrides[get_progress_service] = lambda: DummyProgress()
+    return app
+
+
+def test_upload_rejects_disallowed_type(monkeypatch):
+    monkeypatch.setattr(
+        file_io, "ALLOWED_UPLOAD_MIME_TYPES", {"audio/wav"}, raising=False
+    )
+    # use real save implementation to exercise validation
+    app = build_app(DummyFileIO(file_io.save_upload_file))
+    client = TestClient(app)
+
+    response = client.post(
+        "/upload",
+        files={"file": ("clip.wav", BytesIO(b"12345"), "text/plain")},
+        data={"remove_silence": "false"},
+    )
+    assert response.status_code == 415
+    assert "Unsupported media type" in response.json()["detail"]
+
+
+def test_upload_rejects_oversized_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(file_io, "MAX_UPLOAD_SIZE_BYTES", 5, raising=False)
+    monkeypatch.setattr(
+        file_io, "ALLOWED_UPLOAD_MIME_TYPES", {"audio/wav"}, raising=False
+    )
+    monkeypatch.setattr(file_io, "upload_dir", tmp_path, raising=False)
+
+    app = build_app(DummyFileIO(file_io.save_upload_file))
+    client = TestClient(app)
+
+    response = client.post(
+        "/upload",
+        files={"file": ("clip.wav", BytesIO(b"123456789"), "audio/wav")},
+        data={"remove_silence": "false"},
+    )
+    assert response.status_code == 413
+    assert "File too large" in response.json()["detail"]
+    assert not list(tmp_path.iterdir())


### PR DESCRIPTION
## Summary
- sanitize incoming filenames, enforce upload MIME/size limits, and generate unique storage names when saving files
- update the /upload endpoint to surface clear errors for invalid uploads while keeping background processing behavior
- add unit tests covering file validation, collision avoidance, and upload error responses

## Testing
- python -m pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e67639c588326bd6e315fbfe1c3e3)