### PR TITLE
Handle corrupted progress files

### DIFF
--- a/clipmato/utils/progress.py
+++ b/clipmato/utils/progress.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Any
 
 from .file_io import upload_dir
 from ..config import STAGE_PROGRESS
@@ -16,7 +17,7 @@ def update_progress(record_id: str, stage: str, message: str | None = None) -> N
     status: dict[str, object] = {"stage": stage, "progress": percent}
     if message:
         status["message"] = message
-    get_status_file(record_id).write_text(json.dumps(status))
+    _atomic_write(get_status_file(record_id), status)
 
 
 def read_progress(record_id: str) -> dict:
@@ -24,10 +25,55 @@ def read_progress(record_id: str) -> dict:
     status_file = get_status_file(record_id)
     if status_file.exists():
         try:
-            return json.loads(status_file.read_text())
+            raw_status = json.loads(status_file.read_text())
+            return _validate_status(raw_status)
         except Exception:
-            pass
+            return {
+                "stage": "error",
+                "progress": 0,
+                "error": "invalid_progress_file",
+                "message": "Progress data is unreadable. Please retry or restart this job.",
+            }
     return {"stage": "pending", "progress": 0}
+
+
+def _atomic_write(path: Path, data: dict[str, Any]) -> None:
+    """Atomically write JSON data to ``path`` to avoid partial writes."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(json.dumps(data))
+    tmp_path.replace(path)
+
+
+def _validate_status(raw: Any) -> dict[str, Any]:
+    """
+    Validate a parsed progress payload and normalize it for the API/UI layer.
+
+    Raises:
+        ValueError: if the payload does not contain the expected schema/types.
+    """
+
+    if not isinstance(raw, dict):
+        raise ValueError("Status payload must be a mapping")
+
+    stage = raw.get("stage")
+    progress = raw.get("progress")
+    message = raw.get("message")
+
+    if not isinstance(stage, str):
+        raise ValueError("Status stage must be a string")
+    if not isinstance(progress, (int, float)):
+        raise ValueError("Status progress must be numeric")
+    if message is not None and not isinstance(message, str):
+        raise ValueError("Status message must be a string when provided")
+
+    status: dict[str, Any] = {"stage": stage, "progress": progress}
+    if message:
+        status["message"] = message
+    if "error" in raw and isinstance(raw["error"], str):
+        status["error"] = raw["error"]
+    return status
     
 def enrich_with_progress(records: list[dict]) -> list[dict]:
     """

--- a/tests/test_progress_status.py
+++ b/tests/test_progress_status.py
@@ -1,0 +1,65 @@
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from clipmato.routers.upload import router
+from clipmato.utils import file_io, progress
+
+
+def _build_app():
+    app = FastAPI()
+    app.include_router(router)
+
+    from clipmato.dependencies import (
+        get_file_io_service,
+        get_processing_service,
+    )
+
+    class DummyProcessing:
+        async def process(self, *args, **kwargs):
+            return None
+
+    class DummyFileIO:
+        def save(self, *args, **kwargs):
+            return None
+
+    app.dependency_overrides[get_file_io_service] = lambda: DummyFileIO()
+    app.dependency_overrides[get_processing_service] = lambda: DummyProcessing()
+    return app
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    monkeypatch.setattr(file_io, "upload_dir", tmp_path, raising=False)
+    monkeypatch.setattr(progress, "upload_dir", tmp_path, raising=False)
+    return TestClient(_build_app())
+
+
+def test_progress_reports_truncated_file_error(client, tmp_path):
+    record_id = "abc123"
+    status_path = tmp_path / f"{record_id}.status.json"
+    status_path.write_text('{"stage": "transcribing"')
+
+    response = client.get(f"/progress/{record_id}")
+    body = response.json()
+
+    assert body["stage"] == "error"
+    assert body["progress"] == 0
+    assert body["error"] == "invalid_progress_file"
+    assert "unreadable" in body["message"].lower()
+
+
+def test_progress_reports_invalid_schema_error(client, tmp_path):
+    record_id = "xyz789"
+    status_path = tmp_path / f"{record_id}.status.json"
+    status_path.write_text(json.dumps({"stage": 5, "progress": "oops"}))
+
+    response = client.get(f"/progress/{record_id}")
+    body = response.json()
+
+    assert body["stage"] == "error"
+    assert body["progress"] == 0
+    assert body["error"] == "invalid_progress_file"
+    assert "unreadable" in body["message"].lower()


### PR DESCRIPTION
## Summary
- add atomic writes and schema validation to progress status handling, returning explicit errors when reads fail
- ensure progress API surfaces unreadable status files so the UI can show a recoverable state
- add tests that simulate truncated or invalid status files

## Testing
- OPENAI_API_KEY=test-key PYTHONPATH=. pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e6b8637ec8326b5ab6bea65f2059b)