### PR TITLE
Add locking and atomic writes to metadata utils

### DIFF
--- a/clipmato/utils/metadata.py
+++ b/clipmato/utils/metadata.py
@@ -1,48 +1,109 @@
 import json
+import logging
+import os
+import tempfile
+from contextlib import contextmanager
+
+import fcntl
+
 from ..config import METADATA_PATH
 
 # File where metadata records are stored
 metadata_path = METADATA_PATH
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _locked_metadata_file():
+    """Yield a locked file handle for metadata operations."""
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    with metadata_path.open("a+") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        fh.seek(0)
+        try:
+            yield fh
+        finally:
+            fcntl.flock(fh, fcntl.LOCK_UN)
+
+
+def _atomic_write_records(records: list[dict]) -> None:
+    """Write records to metadata file atomically to prevent corruption."""
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_path = tempfile.mkstemp(dir=metadata_path.parent, prefix="metadata_", suffix=".json")
+    try:
+        with os.fdopen(fd, "w") as tmp_file:
+            json.dump(records, tmp_file, indent=2)
+            tmp_file.flush()
+            os.fsync(tmp_file.fileno())
+        os.replace(temp_path, metadata_path)
+    except Exception:
+        logger.exception("Failed to write metadata atomically")
+        # Best effort cleanup of the temporary file
+        try:
+            os.remove(temp_path)
+        except OSError:
+            pass
+        raise
 
 def read_metadata() -> list[dict]:
     """
     Read the metadata.json file and return the list of processed records.
     """
-    if metadata_path.exists():
-        return json.loads(metadata_path.read_text())
-    return []
+    if not metadata_path.exists():
+        return []
+    try:
+        with metadata_path.open("r") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        logger.exception("Failed to read metadata; returning empty list")
+        return []
 
 def append_metadata(record: dict) -> None:
     """
     Append a new record to the metadata.json file.
     """
-    records = read_metadata()
-    records.append(record)
-    metadata_path.write_text(json.dumps(records, indent=2))
+    try:
+        with _locked_metadata_file():
+            records = read_metadata()
+            records.append(record)
+            _atomic_write_records(records)
+    except Exception:
+        logger.exception("Failed to append metadata record")
+        raise
 
 def update_metadata(record_id: str, updates: dict) -> None:
     """
     Update an existing record in metadata.json by merging in new fields.
     """
-    records = read_metadata()
-    for rec in records:
-        if rec.get("id") == record_id:
-            rec.update(updates)
-            break
-    metadata_path.write_text(json.dumps(records, indent=2))
+    try:
+        with _locked_metadata_file():
+            records = read_metadata()
+            for rec in records:
+                if rec.get("id") == record_id:
+                    rec.update(updates)
+                    break
+            _atomic_write_records(records)
+    except Exception:
+        logger.exception("Failed to update metadata record", extra={"record_id": record_id})
+        raise
 
 def remove_metadata(record_id: str) -> dict | None:
     """
     Remove a record from metadata.json and return the removed record, or None if not found.
     """
-    records = read_metadata()
-    removed = None
-    new_records = []
-    for rec in records:
-        if rec.get("id") == record_id:
-            removed = rec
-        else:
-            new_records.append(rec)
-    if removed:
-        metadata_path.write_text(json.dumps(new_records, indent=2))
-    return removed
+    try:
+        with _locked_metadata_file():
+            records = read_metadata()
+            removed = None
+            new_records = []
+            for rec in records:
+                if rec.get("id") == record_id:
+                    removed = rec
+                else:
+                    new_records.append(rec)
+            if removed:
+                _atomic_write_records(new_records)
+            return removed
+    except Exception:
+        logger.exception("Failed to remove metadata record", extra={"record_id": record_id})
+        raise

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,82 @@
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from clipmato import config
+from clipmato.utils import metadata
+
+
+@pytest.fixture(autouse=True)
+def temp_metadata_file(tmp_path, monkeypatch):
+    path = Path(tmp_path / "metadata.json")
+    monkeypatch.setattr(config, "METADATA_PATH", path, raising=False)
+    monkeypatch.setattr(metadata, "metadata_path", path, raising=False)
+    return path
+
+
+def test_concurrent_appends_produce_valid_json(temp_metadata_file):
+    barrier = threading.Barrier(5)
+    threads = []
+
+    def worker(idx: int):
+        barrier.wait()
+        metadata.append_metadata({"id": f"item-{idx}", "value": idx})
+
+    for i in range(5):
+        thread = threading.Thread(target=worker, args=(i,))
+        thread.start()
+        threads.append(thread)
+
+    for thread in threads:
+        thread.join()
+
+    with temp_metadata_file.open() as fh:
+        records = json.load(fh)
+
+    assert len(records) == 5
+    assert {rec["id"] for rec in records} == {f"item-{i}" for i in range(5)}
+
+
+def test_concurrent_writes_keep_json_valid(temp_metadata_file):
+    initial_records = [
+        {"id": "keep", "value": 1},
+        {"id": "update", "value": 2},
+        {"id": "remove", "value": 3},
+    ]
+    temp_metadata_file.write_text(json.dumps(initial_records, indent=2))
+
+    barrier = threading.Barrier(4)
+    threads = []
+
+    def append_worker():
+        barrier.wait()
+        metadata.append_metadata({"id": "new", "value": 99})
+
+    def update_worker():
+        barrier.wait()
+        metadata.update_metadata("update", {"value": 200})
+
+    def remove_worker():
+        barrier.wait()
+        metadata.remove_metadata("remove")
+
+    def another_append():
+        barrier.wait()
+        metadata.append_metadata({"id": "extra", "value": 42})
+
+    for target in (append_worker, update_worker, remove_worker, another_append):
+        thread = threading.Thread(target=target)
+        thread.start()
+        threads.append(thread)
+
+    for thread in threads:
+        thread.join()
+
+    with temp_metadata_file.open() as fh:
+        records = json.load(fh)
+
+    ids = {rec["id"] for rec in records}
+    assert ids == {"keep", "update", "new", "extra"}
+    assert next(rec for rec in records if rec["id"] == "update")["value"] == 200


### PR DESCRIPTION
## Summary
- add file locking and atomic write logic for metadata read/update operations with error logging
- introduce concurrent write tests ensuring metadata JSON remains valid

## Testing
- OPENAI_API_KEY=test PYTHONPATH=. pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691efd51ba388326a4c65480100f9f33)